### PR TITLE
Working heroku tests

### DIFF
--- a/features/the_innernet/test_theinnernet.py
+++ b/features/the_innernet/test_theinnernet.py
@@ -68,8 +68,6 @@ def test_enable_text_field(Selene: Actor) -> None:
         Eventually(Enter.the_text(test_text).into_the(TEXT_FIELD)),
     )
     then(Selene).should(
-        # I wrote a custom Question to get the contents of an input field, see
-        #  questions/input_text.py
         See.the(InputText.of_the(TEXT_FIELD), ContainsTheText(test_text)),
     )
 
@@ -89,7 +87,5 @@ def test_disable_text_field(Selene: Actor) -> None:
         Wait.for_the(WAITING_TEXT).to_disappear(),
     )
     then(Selene).should(
-        # I wrote a custom resolution function for this, see
-        #  resolutions/is_enabled.py
         See.the(Element(TEXT_FIELD), IsNot(Enabled()))
     )

--- a/features/the_innernet/test_theinnernet.py
+++ b/features/the_innernet/test_theinnernet.py
@@ -7,8 +7,9 @@ from screenpy.actions import Eventually, See
 from screenpy_selenium.actions import Click, Enter, Open, Wait
 from screenpy_selenium.questions import Element
 from screenpy.resolutions import ContainsTheText, IsNot
-from screenpy_selenium.resolutions import Visible
+from screenpy_selenium.resolutions import Visible, IsVisible
 from questions import InputText
+from resolutions import Enabled
 from ui.the_innernet.dynamic_controls import (
     CHECKBOX,
     TEXT_FIELD,
@@ -19,6 +20,7 @@ from ui.the_innernet.dynamic_controls import (
     ENABLE_BUTTON,
     URL
 )
+
 
 def test_remove_checkbox(Selene: Actor) -> None:
     """Test that the checkbox is removed when the remove button is clicked."""
@@ -32,6 +34,25 @@ def test_remove_checkbox(Selene: Actor) -> None:
     then(Selene).should(
         Eventually(See.the(Element(CHECKBOX), IsNot(Visible())))
     )
+
+
+def test_add_checkbox(Selene: Actor) -> None:
+    """Test that the checkbox is added when the Add button is clicked."""
+    given(Selene).was_able_to(
+        Open.their_browser_on(URL),
+        Wait.for_the(CHECKBOX).to_appear(),
+        Click.on_the(REMOVE_BUTTON),
+        Wait.for_the(CHECKBOX).to_disappear(),
+    )
+    when(Selene).attempts_to(
+        Click.on_the(ADD_BUTTON),
+        Wait.for_the(WAITING_TEXT).to_appear(),
+        Wait.for_the(WAITING_TEXT).to_disappear(),
+    )
+    then(Selene).should(
+        Eventually(See.the(Element(CHECKBOX), IsVisible()))
+    )
+
 
 def test_enable_text_field(Selene: Actor) -> None:
     """Test that the text field is enabled by the Enable button, by entering text."""
@@ -47,5 +68,28 @@ def test_enable_text_field(Selene: Actor) -> None:
         Eventually(Enter.the_text(test_text).into_the(TEXT_FIELD)),
     )
     then(Selene).should(
+        # I wrote a custom Question to get the contents of an input field, see
+        #  questions/input_text.py
         See.the(InputText.of_the(TEXT_FIELD), ContainsTheText(test_text)),
+    )
+
+
+def test_disable_text_field(Selene: Actor) -> None:
+    """Test that the text field is disabled by the Disable button."""
+    given(Selene).was_able_to(
+        Open.their_browser_on(URL),
+        Wait.for_the(TEXT_FIELD).to_appear(),
+        Click.on_the(ENABLE_BUTTON),
+        Wait.for_the(WAITING_TEXT).to_appear(),
+        Wait.for_the(WAITING_TEXT).to_disappear(),
+    )
+    when(Selene).attempts_to(
+        Click.on_the(DISABLE_BUTTON),
+        Wait.for_the(WAITING_TEXT).to_appear(),
+        Wait.for_the(WAITING_TEXT).to_disappear(),
+    )
+    then(Selene).should(
+        # I wrote a custom resolution function for this, see
+        #  resolutions/is_enabled.py
+        See.the(Element(TEXT_FIELD), IsNot(Enabled()))
     )

--- a/resolutions/__init__.py
+++ b/resolutions/__init__.py
@@ -1,0 +1,13 @@
+"""
+Custom resolutions to provide answers
+"""
+
+from .is_enabled import IsEnabled
+
+# Natural language sugar
+Enabled = IsEnabled
+
+__all__ = [
+    "Enabled",
+    "IsEnabled",
+]

--- a/resolutions/custom_matchers/__init__.py
+++ b/resolutions/custom_matchers/__init__.py
@@ -1,0 +1,9 @@
+"""
+Custom matcher to extend the functionality of PyHamcrest for this suite.
+"""
+
+from .is_enabled_element import is_enabled_element
+
+__all__ = [
+    "is_enabled_element",
+]

--- a/resolutions/custom_matchers/is_enabled_element.py
+++ b/resolutions/custom_matchers/is_enabled_element.py
@@ -1,0 +1,45 @@
+"""
+A matcher that matches an enabled element. For example:
+
+    assert_that(driver.find_element_by_type("input"), is_enabled_element())
+"""
+
+from typing import Optional
+
+from hamcrest.core.base_matcher import BaseMatcher
+from hamcrest.core.description import Description
+from selenium.webdriver.remote.webelement import WebElement
+
+
+class IsEnabledElement(BaseMatcher[Optional[WebElement]]):
+    """
+    Matches an element whose ``is_enabled`` method returns True.
+    """
+
+    def _matches(self, item: Optional[WebElement]) -> bool:
+        if item is None:
+            return False
+        return item.is_enabled()
+
+    def describe_to(self, description: Description) -> None:
+        """Describe the passing case."""
+        description.append_text("the element is enabled")
+
+    def describe_match(
+        self, item: Optional[WebElement], match_description: Description
+    ) -> None:
+        match_description.append_text("it was enabled")
+
+    def describe_mismatch(
+        self, item: Optional[WebElement], mismatch_description: Description
+    ) -> None:
+        """Describe the failing case."""
+        if item is None:
+            mismatch_description.append_text("was not even present")
+            return
+        mismatch_description.append_text("was not enabled")
+
+
+def is_enabled_element() -> IsEnabledElement:
+    """This matcher matches any element that is enabled."""
+    return IsEnabledElement()

--- a/resolutions/is_enabled.py
+++ b/resolutions/is_enabled.py
@@ -1,0 +1,24 @@
+"""
+Matches against an enabled WebElement.
+"""
+
+from screenpy.resolutions.base_resolution import BaseResolution
+
+from .custom_matchers import is_enabled_element
+from .custom_matchers.is_enabled_element import IsEnabledElement
+
+
+class IsEnabled(BaseResolution):
+    """Match on an enabled element.
+
+    Examples::
+
+        the_actor.should(See.the(Element(TEXT_BOX), IsEnabled()))
+    """
+
+    matcher: IsEnabledElement
+    line = "enabled"
+    matcher_function = is_enabled_element
+
+    def __init__(self) -> None:  # pylint: disable=useless-super-delegation
+        super().__init__()

--- a/ui/the_innernet/dynamic_controls.py
+++ b/ui/the_innernet/dynamic_controls.py
@@ -13,15 +13,12 @@ TEXT_FIELD = Target.the("text field").located_by(
 WAITING_TEXT = Target.the('"Wait for it..." text').located_by(
     '//div[contains(text(), "Wait for it")]'
 )
-
 REMOVE_BUTTON = Target.the("Remove button").located_by(
     '//button[contains(text(), "Remove")]'
 )
-
 ADD_BUTTON = Target.the("Add button").located_by(
     '//button[contains(text(), "Add")]'
 )
-
 DISABLE_BUTTON = Target.the("Disable Button").located_by(
     '//button[contains(text(), "Disable")]'
 )


### PR DESCRIPTION
I ended up having to write a couple of custom extensions to the base framework I'm used to:
1. A Question to examine the contents of an input text field, using selenium's `getProperty` instead of `getAttribute` since text in an active field may not surface in the CSS context
2. A Resolution matching against elements where selenium's `isEnabled = true`

This was a lot of fun to figure out!